### PR TITLE
Add technology comparison to ammonia LCOA GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Amoniaco
 
 Herramienta gráfica para estimar el coste nivelado de producción de amoníaco.
+Permite comparar distintas rutas electroquímicas en una sola interfaz.
 
 ## Uso
 
 Ejecuta `NH3.py` para abrir la interfaz. El programa permite calcular el LCOA y
-realizar distintos análisis de sensibilidad.
+realizar distintos análisis de sensibilidad. Desde el menú superior se puede
+seleccionar la tecnología (**NRR Directa** o **NRR Li-mediada**) y utilizar el
+botón *Comparar tecnologías* para obtener el LCOA de ambas rutas de forma
+simultánea.
 
 ### Nuevas funciones
 
 - Guardar y cargar conjuntos de parámetros en formato JSON desde el menú
   **Archivo**.
 - Restablecer rápidamente los valores por defecto de los parámetros.
+- En la pestaña **Sensibilidades 2D** se puede exportar la curva de paridad
+  para ambas tecnologías en formato CSV. El botón de exportación aparece en
+  la propia ventana del gráfico generado.


### PR DESCRIPTION
## Summary
- Allow selecting between NRR Directa and NRR Li-mediada routes
- Add "Comparar tecnologías" button to compute LCOA for both routes
- Document technology selection and comparison in README
- Enable exporting 2D sensitivity parity curves for both routes

## Testing
- `python -m py_compile NH3.py`


------
https://chatgpt.com/codex/tasks/task_e_68b09e165a0883229c1b17bfa29316d6